### PR TITLE
Add a header to the responses from indexnodes to include their UID (as seen in advert packets).

### DIFF
--- a/src/common/FS2Filter.java
+++ b/src/common/FS2Filter.java
@@ -63,6 +63,7 @@ public class FS2Filter extends Filter {
 	
 	private String alias = "Unnamed";
 	private int port = 0;
+	private long uid = 0;
 	private long queuetoken = 0;
 	private boolean automaticIndexnode;
 	
@@ -82,12 +83,17 @@ public class FS2Filter extends Filter {
 	public void setPort(int inPort) {
 		port = inPort;
 	}
+
+	public void setUID(long newUID) {
+		uid = newUID;
+	}
 	
 	public void doFilter(HttpExchange exchange, Chain chain) throws IOException {
 		Headers h = exchange.getResponseHeaders();
 		h.add("fs2-version", FS2Constants.FS2_PROTOCOL_VERSION);
 		h.add("fs2-port", Integer.toString(port));
 		h.add("fs2-alias", alias);
+		h.add("fs2-indexnode-uid", Long.toString(uid));
 		if (automaticIndexnode) h.add("fs2-automatic", "true");
 		chain.doFilter(exchange);
 	}

--- a/src/indexnode/IndexNode.java
+++ b/src/indexnode/IndexNode.java
@@ -855,6 +855,7 @@ public class IndexNode {
 		
 		fs2Filter.setAlias(conf.getString(IK.ALIAS));
 		fs2Filter.setPort(onPort);
+		fs2Filter.setUID(conf.getLong(IK.ADVERTUID));
 		
 		hh = new HelloHandler();
 		ib = new IndexBrowser(fs);


### PR DESCRIPTION
It would be nice if statically-configured indexnodes (e.g. ones on the internet where the advert packets aren't visible) could be queried for their UID. This would allow us to prevent an indexnode being added more than once, even if it's in a config file more than once (this isn't so trivial to connect as it could be listed by hostname and IP or the box could have multiple IPs or cnames).

fsfuse currently queries statically-configured indexnodes for their protocol version to see if they're valid. This is done by sending an HTTP HEAD request for /. I've added an "indexnode UID" header to the HTTP filter. I think that filter is used for all HTTP responses? E.g. used by clients too? Atm it won't crash, it'll just send 0. This might not be the best behaviour though, might only want to send the header when it's non-0?
